### PR TITLE
Fixes cable8mm/xeed #70

### DIFF
--- a/src/Provider/MysqlProvider.php
+++ b/src/Provider/MysqlProvider.php
@@ -25,7 +25,7 @@ final class MysqlProvider implements ProviderInterface
             : [$table];
 
         foreach ($tables as $table) {
-            $columns = $xeed->pdo->query('SHOW COLUMNS FROM '.$table)->fetchAll(PDO::FETCH_ASSOC);
+            $columns = $xeed->pdo->query('SHOW COLUMNS FROM `'.$table.'`')->fetchAll(PDO::FETCH_ASSOC);
 
             $foreignKeys = $xeed->pdo->query('SELECT * FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_NAME = "'.$table.'" AND TABLE_SCHEMA = "'.$_ENV['DB_DATABASE'].'" AND REFERENCED_TABLE_NAME IS NOT NULL')->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
Added backticks around the table name to prevent errors in relation to MYSQL's reserved keywords: https://dev.mysql.com/doc/refman/9.0/en/keywords.html